### PR TITLE
Add fake client check to CalculateMaxSpeed

### DIFF
--- a/scripting/tf2attribute_support.sp
+++ b/scripting/tf2attribute_support.sp
@@ -582,7 +582,7 @@ MRESReturn OnPlayerCanAirDashPre(int client) {
 }
 
 MRESReturn OnPlayerCalculateMaxSpeedPost(int client, Handle hReturn, Handle hParams) {
-	if (client < 1 || client > MaxClients) {
+	if (client < 1 || client > MaxClients || !IsClientInGame(client) || IsFakeClient(client)) {
 		return MRES_Ignored;
 	}
 	

--- a/scripting/tf2attribute_support.sp
+++ b/scripting/tf2attribute_support.sp
@@ -582,6 +582,10 @@ MRESReturn OnPlayerCanAirDashPre(int client) {
 }
 
 MRESReturn OnPlayerCalculateMaxSpeedPost(int client, Handle hReturn, Handle hParams) {
+	if (client < 1 || client > MaxClients) {
+		return MRES_Ignored;
+	}
+	
 	float flSpeed = DHookGetReturn(hReturn);
 	
 	int activeWeapon = GetEntPropEnt(client, Prop_Send, "m_hActiveWeapon");


### PR DESCRIPTION
```
L 09/03/2023 - 19:55:19: [SM] Exception reported: Entity 22 (22) is invalid
L 09/03/2023 - 19:55:19: [SM] Blaming: tf2attribute_support.smx
L 09/03/2023 - 19:55:19: [SM] Call stack trace:
L 09/03/2023 - 19:55:19: [SM]   [0] GetEntPropEnt
L 09/03/2023 - 19:55:19: [SM]   [1] Line 587, C:\suspawn\mystuff_7040\scripting\tf2attribute_support.sp::OnPlayerCalculateMaxSpeedPost
```
This error also is occurred in SM 1.11. It seems to enough adding index check.