### PR TITLE
Add real item check on set_turn_to_ice

### DIFF
--- a/scripting/tf2attribute_support.sp
+++ b/scripting/tf2attribute_support.sp
@@ -1151,8 +1151,11 @@ MRESReturn OnPlayerKilledPre(int client, Handle hParams) {
 	int weapon = DHookGetParamObjectPtrVar(hParams, 1, offs_CTakeDamageInfo_hWeapon,
 			ObjectValueType_Ehandle);
 	
-	g_bShouldTurnToIce[client] = IsValidEntity(weapon)
-			&& HasEntProp(weapon, Prop_Send, "m_AttributeList") && TF2Attrib_HookValueInt(0, "set_turn_to_ice", weapon);
+	if (!IsValidEntity(weapon) || !weapon) {
+		return;
+	} else if (TF2Util_IsEntityWeapon(weapon) || TF2Util_IsEntityWearable(weapon)) {
+		g_bShouldTurnToIce[client] = TF2Attrib_HookValueInt(0, "set_turn_to_ice", weapon) != 0;
+	}
 	
 	return MRES_Ignored;
 }

--- a/scripting/tf2attribute_support.sp
+++ b/scripting/tf2attribute_support.sp
@@ -1152,7 +1152,7 @@ MRESReturn OnPlayerKilledPre(int client, Handle hParams) {
 			ObjectValueType_Ehandle);
 	
 	g_bShouldTurnToIce[client] = IsValidEntity(weapon)
-			&& TF2Attrib_HookValueInt(0, "set_turn_to_ice", weapon);
+			&& HasEntProp(weapon, Prop_Send, "m_AttributeList") && TF2Attrib_HookValueInt(0, "set_turn_to_ice", weapon);
 	
 	return MRES_Ignored;
 }

--- a/scripting/tf2attribute_support.sp
+++ b/scripting/tf2attribute_support.sp
@@ -1152,7 +1152,7 @@ MRESReturn OnPlayerKilledPre(int client, Handle hParams) {
 			ObjectValueType_Ehandle);
 	
 	if (!IsValidEntity(weapon) || !weapon) {
-		return;
+		return MRES_Ignored;
 	} else if (TF2Util_IsEntityWeapon(weapon) || TF2Util_IsEntityWearable(weapon)) {
 		g_bShouldTurnToIce[client] = TF2Attrib_HookValueInt(0, "set_turn_to_ice", weapon) != 0;
 	}


### PR DESCRIPTION
- Add exclusion when someone cause damage through `env_explosion` or world.
```
L 11/28/2023 - 19:19:50: [SM] Exception reported: World not allowed
L 11/28/2023 - 19:19:50: [SM] Blaming: tf2attributes.smx
L 11/28/2023 - 19:19:50: [SM] Call stack trace:
L 11/28/2023 - 19:19:50: [SM]   [0] SDKCall
L 11/28/2023 - 19:19:50: [SM]   [1] Line 911, /scratch/scripting/tf2attributes.sp::Native_HookValueInt
L 11/28/2023 - 19:19:50: [SM]   [3] TF2Attrib_HookValueInt
L 11/28/2023 - 19:19:50: [SM]   [4] Line 1114, C:\suspawn\mystuff_7040\scripting\tf2attribute_support.sp::OnPlayerKilledPre
L 11/28/2023 - 19:19:50: [SM]   [6] SDKHooks_TakeDamage
L 11/28/2023 - 19:19:50: [SM]   [7] Line 428, C:\suspawn\mystuff_7040\scripting\joke_medigun_mod_drain_health.sp::MedicDetonate
L 11/28/2023 - 19:19:50: [SM]   [8] Line 395, C:\suspawn\mystuff_7040\scripting\joke_medigun_mod_drain_health.sp::OnMedigunSecondaryAttackPre
```