### PR TITLE
Prevent steal burn damage

### DIFF
--- a/scripting/tf2attribute_support.sp
+++ b/scripting/tf2attribute_support.sp
@@ -1109,8 +1109,10 @@ void ApplyItemBurnModifier(int weapon, int victim, int attacker) {
 	}
 	
 	float burnTime = TF2Attrib_HookValueFloat(0.0, "set_dmgtype_ignite", weapon);
-	float currentBurnTime = TF2Util_GetPlayerBurnDuration(victim);
-	TF2Util_IgnitePlayer(victim, attacker, burnTime - currentBurnTime, weapon);
+	if (burnTime > 0.0) {
+		float currentBurnTime = TF2Util_GetPlayerBurnDuration(victim);
+		TF2Util_IgnitePlayer(victim, attacker, burnTime - currentBurnTime, weapon);
+	}
 }
 
 /**


### PR DESCRIPTION
I realized that I didn't update this plugin after pulling last request. So, I didn't recognize existence of this bug.
* Previous logic ignited player even if burntime is 0.0.
* As a result, Someone hit burning player, attacker is changed.