### PR TITLE
Update for TF2 version 9543365 (2025-02-18)

### DIFF
--- a/gamedata/tf2.attribute_support.txt
+++ b/gamedata/tf2.attribute_support.txt
@@ -282,7 +282,7 @@
 				"signature"		"CTFPlayer::CanAirDash()"
 				"linux"
 				{
-					"offset"	"B6h"
+					"offset"	"CAh"
 					"verify"	"\xC1\x0F\x2F\x05\x2A\x2A\x2A\x2A"
 					"patch"		"\xC1\x0F\x2F\x05\x00\x00\x00\x00"
 				}


### PR DESCRIPTION
Fixes the error “Failed to validate patch CTFPlayer::CanAirDash()::PatchRequiredDeployTime”